### PR TITLE
Use macOS SD-Card icon instead of the generic one

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,5 @@ From higher to lower priority:
  - Troubleshoot why after a soft reboot, for chip 525A version B, chip version is detected as 'A'.
  - Use command gate instead of two workloops? Is it even possible?
  - Prevent namespace pollution (OpenBSD functions pollute the namespace and may cause collisions).
- - Use macOS SD-Card icon instead of the generic one.
 
 Pull requests are very welcome, specially to add support for chips other than RTS525A (the only chip I can test).

--- a/Sinetek-rtsx/SDDisk.cpp
+++ b/Sinetek-rtsx/SDDisk.cpp
@@ -3,6 +3,7 @@
 #include <IOKit/IOLib.h>
 #include <IOKit/storage/IOBlockStorageDevice.h>
 #include <IOKit/storage/IOBlockStorageDriver.h> // kIOMediaStateOffline
+#include <IOKit/storage/IOMedia.h> // kIOMediaIconKey
 #include <IOKit/IOMemoryDescriptor.h>
 
 #define UTL_THIS_CLASS "SDDisk::"
@@ -59,6 +60,20 @@ static void dma_free(void *kva, bus_size_t bufSize, bus_dma_segment_t *dma_segs,
 	bus_dmamem_free(gBusDmaTag, dma_segs, rsegs);
 }
 
+static void setIcon(IOService *sddiskIOService)
+{
+	OSDictionary *dictionary = OSDictionary::withCapacity(2);
+	OSString *identifier = OSString::withCString("com.apple.iokit.IOSCSIArchitectureModelFamily");
+	OSString *resourceFile = OSString::withCString("SD.icns");
+
+	if (dictionary && identifier && resourceFile) {
+		dictionary->setObject("CFBundleIdentifier", identifier);
+		dictionary->setObject("IOBundleResourceFile", resourceFile);
+	}
+
+	sddiskIOService->setProperty(kIOMediaIconKey, dictionary);
+}
+
 } // namespace
 
 bool SDDisk::init(struct sdmmc_softc *sc_sdmmc, OSDictionary* properties)
@@ -74,6 +89,7 @@ bool SDDisk::init(struct sdmmc_softc *sc_sdmmc, OSDictionary* properties)
 	debugRetainReleaseCount = 0;
 #endif
 
+	setIcon(this);
 
 	UTL_DEBUG_FUN("END");
 	return true;


### PR DESCRIPTION
This pull request sets the same icon used by Apple SD card reader kext for the SDDisk IOService.

<img width="304" alt="Screen Shot 2021-02-13 at 20 23 27" src="https://user-images.githubusercontent.com/590045/107864546-14bdac80-6e3c-11eb-89ef-0554429077c5.png">
