### PR TITLE
RTS522A available to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It took me a while to understand the code. Some problems I found:
 | RTS5227  | Seems to work fine with sleep disabled. Adding boot parameter `rtsx_sleep_wake_delay_ms=1000` may help with sleep/wake. (See PR #18) |
 | RTS525A  | Working fine with sleep disabled. Enabling sleep may make the kext unstable. Some cards may not be recognized.                       |
 | RTS5287  | Working fine with sleep disabled. Not waking from sleep. (See issue #19)                                                             |
+| RTS522A  | Working fine with skeeo disabled. Not working after sleep and wakes up sleep constantly                                              |
 
  _If you have a chip other than RTS525A and this kext is working for you, please let me know and I will update this table._
 


### PR DESCRIPTION
This kext works correctly with RTS522A but it wakes up sleep and doesn't work after sleep, so disabling sleep or rebooting after sleep is required.

On disk read/write, it shows speed Read: 4.5Mbps, Write: 8Mbps